### PR TITLE
[jinja2] don't encode output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
+sudo: false
+branches:
+  only:
+    - master
 language: python
-python:
-  - 2.6
-  - 2.7
-install:
-  - python build.py dev
-script: python build.py analyse
+python: "3.5"
+install: pip install tox
+script: tox
 notifications:
   email: false
-  irc: 
+  irc:
     channels:
       - "irc.freenode.org#aspen"
     on_success: change

--- a/aspen_jinja2/aspen_jinja2_renderer.py
+++ b/aspen_jinja2/aspen_jinja2_renderer.py
@@ -1,10 +1,9 @@
 """Implement a Jinja2 renderer.
 
 Jinja2 insists on unicode, and explicit loader objects. We assume with Jinja2
-that your templates on the filesystem be encoded in UTF-8 (the result of the
-template will be encoded to bytes for the wire per response.charset). We shim a
-loader that returns the decoded content page and instructs Jinja2 not to
-perform auto-reloading.
+that your templates on the filesystem are encoded in UTF-8. We shim a loader
+that returns the decoded content page and instructs Jinja2 not to perform
+auto-reloading.
 
 """
 from __future__ import absolute_import, unicode_literals
@@ -75,10 +74,9 @@ class Renderer(renderers.Renderer):
         return SimplateLoader(filepath, raw).load(environment, filepath)
 
     def render_content(self, context):
-        charset = context['response'].charset
         # Inject globally-desired context
         context.update(self.global_context)
-        return self.compiled.render(context).encode(charset)
+        return self.compiled.render(context)
 
 
 class Factory(renderers.Factory):

--- a/aspen_tornado/aspen_tornado_renderer.py
+++ b/aspen_tornado/aspen_tornado_renderer.py
@@ -11,7 +11,8 @@ class Renderer(renderers.Renderer):
         return Template(raw, filepath, loader, compress_whitespace=False)
 
     def render_content(self, context):
-        return self.compiled.generate(**context)
+        # tornado seems to always return utf8
+        return self.compiled.generate(**context).decode('utf8')
 
 
 class Factory(renderers.Factory):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,25 @@
 
+import sys
+
 import pytest
-from aspen.testing.harness import teardown
-from aspen.testing.pytest_fixtures import client, harness, fs
-from aspen.testing.pytest_fixtures import sys_path, sys_path_scrubber
+from aspen.testing import teardown, Harness
+
+
+@pytest.yield_fixture
+def harness(sys_path_scrubber):
+    harness = Harness()
+    yield harness
+    harness.teardown()
+
 
 def pytest_runtest_teardown():
     teardown()
 
+
+@pytest.yield_fixture
+def sys_path_scrubber():
+    before = set(sys.path)
+    yield
+    after = set(sys.path)
+    for name in after - before:
+        sys.path.remove(name)

--- a/tests/test_jinja2.py
+++ b/tests/test_jinja2.py
@@ -7,10 +7,10 @@ Greetings, {{name}}!
 
 
 def test_basic_jinja2_template(harness):
-    harness.client.website.renderer_default = 'stdlib_format'
+    harness.request_processor.renderer_default = 'stdlib_format'
     harness.fs.www.mk(('index.html.spt', GREETINGS % 'program'),)
-    r = harness.client.GET('/')
-    assert r.body == 'Greetings, program!'
+    r = harness._hit('GET', '/')
+    assert r.body == b'Greetings, program!'
 
 
 def test_global_context_jinja2_template(harness):
@@ -19,26 +19,26 @@ def test_global_context_jinja2_template(harness):
     [----] via jinja2
     len: {{ len(longDict) }}
     """
-    website = harness.client.website
-    website.renderer_default = 'stdlib_format'
-    website.renderer_factories['jinja2'].Renderer.global_context = {
+    rp = harness.request_processor
+    rp.renderer_default = 'stdlib_format'
+    rp.renderer_factories['jinja2'].Renderer.global_context = {
         'len': len
     }
     harness.fs.www.mk(('jinja2-global.html.spt', SIMPLATE),)
-    r = harness.client.GET('/jinja2-global.html')
-    assert r.body == 'len: 3'
+    r = harness._hit('GET', '/jinja2-global.html')
+    assert r.body == b'len: 3'
 
 
 def test_autoescape_off(harness):
-    harness.client.website.renderer_factories['jinja2'].Renderer.autoescape = False
+    harness.request_processor.renderer_factories['jinja2'].Renderer.autoescape = False
     harness.fs.www.mk(('index.html.spt', GREETINGS % '<foo>'),)
-    r = harness.client.GET('/')
-    assert r.body == 'Greetings, <foo>!'
+    r = harness._hit('GET', '/')
+    assert r.body == b'Greetings, <foo>!'
 
 
 def test_autoescape_on(harness):
-    harness.client.website.renderer_factories['jinja2'].Renderer.autoescape = True
+    harness.request_processor.renderer_factories['jinja2'].Renderer.autoescape = True
     harness.fs.www.mk(('index.html.spt', GREETINGS % '<foo>'),)
-    r = harness.client.GET('/')
-    assert r.body == 'Greetings, &lt;foo&gt;!'
+    r = harness._hit('GET', '/')
+    assert r.body == b'Greetings, &lt;foo&gt;!'
 

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -25,6 +25,17 @@ def test_basic_tornado_template(harness):
     assert_body(harness, '/', 'Greetings, program!\n')
 
 
+def test_unicode_tornado_template(harness):
+    SIMPLATE = u"""
+    # coding: latin9
+    [----] via tornado
+    \u20ac
+    """
+    harness.request_processor.renderer_default = 'stdlib_format'
+    harness.fs.www.mk(('index.html.spt', SIMPLATE, True, 'latin9'),)
+    assert_body(harness, '/', u'\u20ac\n')
+
+
 def test_tornado_can_load_bases(harness):
     harness.fs.project.mk(("base.html", "{% block foo %}{% end %} Blam."))
     SIMPLATE = """

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -9,7 +9,8 @@ import sys
 
 
 def assert_body(harness, uripath, expected_body):
-    actual = harness.simple(filepath=None, uripath=uripath, want='response.body')
+    actual = harness.simple(filepath=None, uripath=uripath, want='output.body',
+                            return_after='render_resource')
     assert actual == expected_body
 
 
@@ -19,7 +20,7 @@ def test_basic_tornado_template(harness):
     [----] via tornado
     Greetings, {{name}}!
     """
-    harness.client.website.renderer_default = 'stdlib_format'
+    harness.request_processor.renderer_default = 'stdlib_format'
     harness.fs.www.mk(('index.html.spt', SIMPLATE),)
     assert_body(harness, '/', 'Greetings, program!\n')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py27,py33,py34,py35
+skipsdist = True
+
+[testenv]
+commands =
+    pip install -q -e {toxinidir}/aspen_jinja2
+    pip install -q -e {toxinidir}/aspen_tornado
+    python -m pytest --cov aspen_jinja2_renderer --cov aspen_tornado_renderer --cov-report term-missing {toxinidir}/tests
+deps =
+    aspen >= 1.0rc1
+    pytest
+    pytest-cov


### PR DESCRIPTION
It's not the plugin's job to encode. Moreover, `response.charset` is specific to Pando (and will probably be pruned from it).