### PR TITLE
Sync Jinja's `auto_reload` to Aspen's `changes_reload`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
-sudo: false
+dist: xenial
 branches:
   only:
     - master
 language: python
-python: "3.5"
-install: pip install tox
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: travis_retry pip install tox-travis
 script: tox
 notifications:
   email: false

--- a/aspen_jinja2/aspen_jinja2_renderer.py
+++ b/aspen_jinja2/aspen_jinja2_renderer.py
@@ -88,8 +88,12 @@ class Factory(renderers.Factory):
         if configuration.project_root is not None:
             # Instantiate a loader that will be used to resolve template bases.
             loader = FileSystemLoader(configuration.project_root)
+        common_options = dict(
+            loader=loader,
+            auto_reload=configuration.changes_reload,
+        )
         return {
-            'default_env': Environment(loader=loader),
-            'htmlescaped_env': Environment(loader=loader, autoescape=True),
+            'default_env': Environment(**common_options),
+            'htmlescaped_env': Environment(autoescape=True, **common_options),
         }
 

--- a/aspen_jinja2/aspen_jinja2_renderer.py
+++ b/aspen_jinja2/aspen_jinja2_renderer.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 
-from aspen import renderers
+from aspen.simplates import renderers
 from jinja2 import BaseLoader, Environment, FileSystemLoader
 
 

--- a/aspen_pystache/aspen_pystache.py
+++ b/aspen_pystache/aspen_pystache.py
@@ -1,6 +1,6 @@
 
 from __future__ import absolute_import
-from aspen import renderers
+from aspen.simplates import renderers
 import pystache
 
 

--- a/aspen_tornado/aspen_tornado_renderer.py
+++ b/aspen_tornado/aspen_tornado_renderer.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from aspen import renderers
+from aspen.simplates import renderers
 from tornado.template import Loader, Template
 import os
 

--- a/tests/test_jinja2.py
+++ b/tests/test_jinja2.py
@@ -1,3 +1,5 @@
+import aspen_jinja2_renderer
+
 
 GREETINGS = """
 name="%s"
@@ -7,7 +9,7 @@ Greetings, {{name}}!
 
 
 def test_basic_jinja2_template(harness):
-    harness.request_processor.renderer_default = 'stdlib_format'
+    harness.hydrate_request_processor(renderer_default='stdlib_format')
     harness.fs.www.mk(('index.html.spt', GREETINGS % 'program'),)
     r = harness._hit('GET', '/')
     assert r.body == b'Greetings, program!'
@@ -19,9 +21,8 @@ def test_global_context_jinja2_template(harness):
     [----] via jinja2
     len: {{ len(longDict) }}
     """
-    rp = harness.request_processor
-    rp.renderer_default = 'stdlib_format'
-    rp.renderer_factories['jinja2'].Renderer.global_context = {
+    harness.hydrate_request_processor(renderer_default='stdlib_format')
+    aspen_jinja2_renderer.Renderer.global_context = {
         'len': len
     }
     harness.fs.www.mk(('jinja2-global.html.spt', SIMPLATE),)
@@ -30,14 +31,14 @@ def test_global_context_jinja2_template(harness):
 
 
 def test_autoescape_off(harness):
-    harness.request_processor.renderer_factories['jinja2'].Renderer.autoescape = False
+    aspen_jinja2_renderer.Renderer.autoescape = False
     harness.fs.www.mk(('index.html.spt', GREETINGS % '<foo>'),)
     r = harness._hit('GET', '/')
     assert r.body == b'Greetings, <foo>!'
 
 
 def test_autoescape_on(harness):
-    harness.request_processor.renderer_factories['jinja2'].Renderer.autoescape = True
+    aspen_jinja2_renderer.Renderer.autoescape = True
     harness.fs.www.mk(('index.html.spt', GREETINGS % '<foo>'),)
     r = harness._hit('GET', '/')
     assert r.body == b'Greetings, &lt;foo&gt;!'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py34,py35,py36
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR turns off Jinja's automatic reloading of templates when Aspen's automatic reloading of simplates is disabled.

From [jinja's doc](http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment):

> *auto_reload*
> Some loaders load templates from locations where the template sources may change (ie: file system or database). If `auto_reload` is set to `True` (default) every time a template is requested the loader checks if the source changed and if yes, it will reload the template. For higher performance it’s possible to disable that.
